### PR TITLE
Pre Increment / Decrement False Positive Fix

### DIFF
--- a/NormEZ.rb
+++ b/NormEZ.rb
@@ -554,10 +554,10 @@ class CodingStyleChecker
       line.scan(/([^a-zA-Z0-9]sizeof )/) do
         put_error_sign("sizeof", line_nb)
       end
-      line.scan(/([^a-zA-Z]\+\+[^a-zA-Z])/) do
+      line.scan(/([^a-zA-Z\t ]\+\+[^a-zA-Z])/) do
         put_error_sign("++", line_nb)
       end
-      line.scan(/([^a-zA-Z]--[^a-zA-Z])/) do
+      line.scan(/([^a-zA-Z\t ]--[^a-zA-Z])/) do
         put_error_sign("--", line_nb)
       end
       line_nb += 1


### PR DESCRIPTION
Fixes Increment / Decrement when the signs are followed by a special char (i.e: `\t++(*a);`).