### PR TITLE
use arguments as files

### DIFF
--- a/NormEZ.rb
+++ b/NormEZ.rb
@@ -105,9 +105,10 @@ class FilesRetriever
   @@ignore = nil
 
   def initialize
-    @files = Dir['**/*'].select { |f| File.file? f }
+    @files = ARGV.select { |f| File.file? f }
+    @files = Dir['**/*'].select { |f| File.file? f } if @files.count.zero?
+
     if File.file?('.gitignore')
-      line_num = 0
       gitignore = FileManager.new('.gitignore', FileType::UNKNOWN).get_content
       gitignore.gsub!(/\r\n?/, "\n")
       @@ignore = []


### PR DESCRIPTION
I wanted to use the script on the specific files passed as arguments.
This PR add this feature.

```sh
ruby NormEZ.rb -c  README.md ../pointer.c
```

The old behaviour stays naturally the same :
```sh
ruby NormEZ.rb -c  
```

```sh
ruby NormEZ.rb
```